### PR TITLE
Create v2023.json

### DIFF
--- a/v2023.json
+++ b/v2023.json
@@ -1,0 +1,120 @@
+{
+  "@context": [
+      "https://opensource.ieee.org/scd/v2023.json",
+          {
+            "@version": "2023",
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "CompetencyDefinition": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#CompetencyDefinition",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "competencyStatement": "rdf:langString",
+                    "competencyLevel": "RubricCriterionLevel",
+                    "description": "rdf:langString",
+                    "hasCompetencyFramework": "@id",
+                    "hasCriterion": "Criterion",
+                    "id": "@id",
+                    "name": "rdf:langString",
+                    "referenceCode": "rdf:Literal",
+                    "resourceAssociation": "rdfs:Resource",
+        		    "competencyType": "skos:Concept",
+        		    "competencyTypeLabel": "rdf:langString"
+                }
+            },
+
+            "CompetencyFramework": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#CompetencyFramework",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",  
+
+                    "name": "rdf:langString",
+                    "description": "rdf:langString",
+                    "hasCompetencyDefinition": "CompetencyDefinition",
+                    "hasRubric": "Rubric",
+                    "id": "@id",
+                    "originalFramework": "rdfs:Resource",
+                    "resourceAssociation": "ResourceAssociaiton"
+                }
+            },
+
+            "CompetencyAssociation": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#CompetencyAssociation",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "associationType": "skos:Concept",
+                    "destination": "rdfs:Resource",
+                    "id": "@id",
+                    "source": "rdfs:Resource",
+                    "hasCompetencyFramrwork": "CompetencyFramework",
+                    "weight": "rdfs:Literal"
+                }
+            },
+
+            "Rubric": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#Rubric",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "id": "@id",
+                    "description":"rdf:langString",
+                    "method":"skos:Concept",
+                    "name":"rdf:langString",
+                    "rubricCriterion":"RubricCriterion"
+                }
+            },
+                
+            "RubricCriterion": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#RubricCriterion",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+                    
+                    "id": "@id",
+                    "name": "rdf:langString",
+                    "category": "rdf:langString",
+                    "description": "rdf:langString",
+                    "position": "rdf:langString",
+                    "rubricCriterionLevel": "RubricCriterionLevel",
+                    "weight": "rdfs:Literal"
+                }
+            },
+                
+            "RubricCriterionLevel": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#RubricCriterionLevel",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "id": "@id",
+                    "name": "rdf:langString",
+                    "description": "rdf:langString",
+                    "feedback": "rdf:langString",
+                    "position": "rdfs:Literal",
+                    "score": "rdfs:Literal"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This context aligns with the approved draft of 1484.20.3.

...with one difference in terms.  In the spec we have:
 5.1.10 | type | Type, class, or category of the competency. Comment 1: The referenced resource is a type defining a: (1) level in a hierarchical framework (e.g., “subject,” “strand,” “standard,” “benchmark,” “indicator,” “task”); (2) functional class (e.g., “condition,” “context,” “criteria,” “outcome”); or (3) a category (e.g., “knowledge,” “skill,” “ability,” “behavior,” “habit of mind or practice”). Comment 2: The preference is for the types to be defined as concepts (skos:Concept) in a machine-actionable concept scheme (skos:ConceptScheme). | skos:Concept | O | 0..*

"type" is reserved as the class @type, so changed terms to competencyType, competencyLabelType here. Maybe that was a typo in the approved draft because I thought we talked about that issue. -- If that's this name change is the only solution then we'll need to revise the standard or otherwise signal with an addendum or note.
